### PR TITLE
Set `child_plugin` to salting plugins

### DIFF
--- a/axidence/plugins/salting/event_building.py
+++ b/axidence/plugins/salting/event_building.py
@@ -10,6 +10,7 @@ from ...plugin import ExhaustPlugin
 
 class EventsSalted(Events, ExhaustPlugin):
     __version__ = "0.1.0"
+    child_plugin = True
     depends_on = ("peaks_salted", "peak_proximity_salted", "peak_basics", "peak_proximity")
     provides = "events_salted"
     data_kind = "events_salted"
@@ -111,6 +112,7 @@ class EventsSalted(Events, ExhaustPlugin):
 
 class EventBasicsSalted(EventBasics, ExhaustPlugin):
     __version__ = "0.0.0"
+    child_plugin = True
     depends_on: Tuple[str, ...] = (
         "events_salted",
         "peaks_salted",

--- a/axidence/plugins/salting/peak_correlation.py
+++ b/axidence/plugins/salting/peak_correlation.py
@@ -8,6 +8,7 @@ from ...utils import copy_dtype
 
 class PeakProximitySalted(PeakProximity):
     __version__ = "0.0.0"
+    child_plugin = True
     depends_on = ("peaks_salted", "peak_basics")
     provides = "peak_proximity_salted"
     data_kind = "peaks_salted"
@@ -60,6 +61,7 @@ class PeakProximitySalted(PeakProximity):
 
 class PeakShadowSalted(PeakShadow):
     __version__ = "0.0.0"
+    child_plugin = True
     depends_on = ("peaks_salted", "peak_basics", "peak_positions")
     provides = "peak_shadow_salted"
     data_kind = "peaks_salted"
@@ -80,6 +82,7 @@ class PeakShadowSalted(PeakShadow):
 
 class PeakAmbienceSalted(PeakAmbience):
     __version__ = "0.0.0"
+    child_plugin = True
     depends_on = ("peaks_salted", "lone_hits", "peak_basics", "peak_positions")
     provides = "peak_ambience_salted"
     data_kind = "peaks_salted"
@@ -100,6 +103,7 @@ class PeakAmbienceSalted(PeakAmbience):
 
 class PeakNearestTriggeringSalted(PeakNearestTriggering):
     __version__ = "0.0.0"
+    child_plugin = True
     depends_on = ("peaks_salted", "peak_proximity_salted", "peak_basics", "peak_proximity")
     provides = "peak_nearest_triggering_salted"
     data_kind = "peaks_salted"
@@ -120,6 +124,7 @@ class PeakNearestTriggeringSalted(PeakNearestTriggering):
 
 class PeakSEDensitySalted(PeakSEDensity):
     __version__ = "0.0.0"
+    child_plugin = True
     depends_on = ("peaks_salted", "peak_basics", "peak_positions")
     provides = "peak_se_density_salted"
     data_kind = "peaks_salted"


### PR DESCRIPTION
Because they borrowed the functions but not the lineage.

In other words, if the lineage is sensitive to the change of version of the base class, like `EventShadowSalted`, it is fine to not set the `child_plugin` to be `True`. But for plugins that only borrow the methods, like `EventBasicsSalted`, we need to make sure that the lineage tracks the version change of `EventBasics`.

To test this, without `child_plugin=True`, when `__version__` of `straxen.EventBasics` is changed, the linage or hash of `EventBasicsSalted` will not change.

It would be better if we could use https://github.com/XENONnT/straxen/pull/1273 to test this PR. But it is OK because it is not merged.

close https://github.com/dachengx/axidence/issues/42