### PR TITLE
Add `run_meta` as the dependency of `PeaksPaired` and store `run_id` into `peaks_paired`

### DIFF
--- a/axidence/plugins/isolated/isolated_s1.py
+++ b/axidence/plugins/isolated/isolated_s1.py
@@ -41,6 +41,7 @@ class IsolatedS1(Plugin):
         dtype_reference = self.refer_dtype("peaks")
         dtype = copy_dtype(dtype_reference, self.isolated_peaks_fields)
         dtype += [
+            (("Run id", "run_id"), np.int32),
             (("Group number of peaks", "group_number"), np.int64),
         ]
         return dtype
@@ -49,9 +50,10 @@ class IsolatedS1(Plugin):
         _result = peaks[peaks["cut_isolated_s1"]]
         result = np.empty(len(_result), dtype=self.dtype)
         for n in result.dtype.names:
-            if n not in ["group_number"]:
+            if n not in ["run_id", "group_number"]:
                 result[n] = _result[n]
 
+        result["run_id"] = int(self.run_id)
         result["group_number"] = np.arange(len(result)) + self.groups_seen
 
         self.groups_seen += len(result)

--- a/axidence/plugins/isolated/isolated_s2.py
+++ b/axidence/plugins/isolated/isolated_s2.py
@@ -56,6 +56,7 @@ class IsolatedS2(Plugin):
         dtype = copy_dtype(self.refer_dtype("peaks"), self.isolated_peaks_fields)
         dtype += copy_dtype(self.refer_dtype("events"), self.isolated_events_fields)
         dtype += [
+            (("Run id", "run_id"), np.int32),
             (("Group number of peaks", "group_number"), np.int64),
         ]
         return dtype
@@ -69,7 +70,7 @@ class IsolatedS2(Plugin):
 
         result = np.empty(_events["n_peaks"].sum(), dtype=self.dtype)
         for n in result.dtype.names:
-            if n not in ["group_number"]:
+            if n not in ["run_id", "group_number"]:
                 if n in self.isolated_peaks_fields:
                     result[n] = _peaks[n]
                 elif n in self.isolated_events_fields:
@@ -77,6 +78,7 @@ class IsolatedS2(Plugin):
                 else:
                     raise ValueError(f"Field {n} not found in peaks or events!")
 
+        result["run_id"] = int(self.run_id)
         result["group_number"] = (
             np.repeat(np.arange(len(_events)), _events["n_peaks"]) + self.groups_seen
         )

--- a/axidence/plugins/pairing/events_paired.py
+++ b/axidence/plugins/pairing/events_paired.py
@@ -85,9 +85,8 @@ class EventInfosPaired(Events):
             "left_dtime",
             "right_dtime",
         ]
-        # TODO: reconsider about how to store run_id after implementing super runs
         required_names += [
-            # "origin_run_id",
+            "origin_run_id",
             "origin_group_number",
             "origin_time",
             "origin_endtime",


### PR DESCRIPTION
close https://github.com/dachengx/axidence/issues/36

The issue can be closed because we can use super runs to combine runs before bootstraping, so that the run boundary is not a problem.