### PR TITLE
Veto aware salting

### DIFF
--- a/axidence/context.py
+++ b/axidence/context.py
@@ -6,7 +6,7 @@ from strax import LoopPlugin, CutPlugin, CutList
 import straxen
 from straxen import EventBasicsSOM, EventInfoDouble
 
-from axidence import RunMeta, EventsSalting, PeaksSalted
+from axidence import RunMeta, EventsSalting, VetoAwareEventSalting, PeaksSalted
 from axidence import (
     PeakProximitySalted,
     PeakShadowSalted,
@@ -291,12 +291,13 @@ def replication_tree(
 
 
 @strax.Context.add_method
-def _salt_to_context(self):
+def _salt_to_context(self, veto_aware=False):
     """Register the salted plugins to the context."""
+    VetoAwareSaltingPlugin = VetoAwareEventSalting if veto_aware else EventsSalting
     self.register(
         (
             RunMeta,
-            EventsSalting,
+            VetoAwareSaltingPlugin,
             PeaksSalted,
             PeakProximitySalted,
             PeakShadowSalted,
@@ -333,19 +334,19 @@ def _pair_to_context(self):
 
 
 @strax.Context.add_method
-def salt_to_context(st, assign_attributes=None, tqdm_disable=True):
+def salt_to_context(st, assign_attributes=None, tqdm_disable=True, veto_aware=False):
     """Register the salted plugins to the context."""
     st.register((MainS1Trigger, MainS2Trigger, EventBuilding))
     st.replication_tree(
         suffixes=["Salted"], assign_attributes=assign_attributes, tqdm_disable=tqdm_disable
     )
-    st._salt_to_context()
+    st._salt_to_context(veto_aware=veto_aware)
 
 
 @strax.Context.add_method
-def salt_and_pair_to_context(st, assign_attributes=None, tqdm_disable=True):
+def salt_and_pair_to_context(st, assign_attributes=None, tqdm_disable=True, veto_aware=False):
     """Register the salted and paired plugins to the context."""
     st.register((MainS1Trigger, MainS2Trigger, EventBuilding))
     st.replication_tree(assign_attributes=assign_attributes, tqdm_disable=tqdm_disable)
-    st._salt_to_context()
+    st._salt_to_context(veto_aware=veto_aware)
     st._pair_to_context()

--- a/axidence/plugins/salting/events_salting.py
+++ b/axidence/plugins/salting/events_salting.py
@@ -299,6 +299,7 @@ class VetoAwareEventSalting(EventsSalting):
                 f"Vetoed {self.n_events - np.sum(mask)} salting events due to veto intervals."
             )
             self.events_salting = self.events_salting[mask]
+            self.events_salting -= self.events_salting[0]["salt_number"]  # Re-index salt_number
             self.n_events = len(self.events_salting)
 
         for chunk_i in range(len(self.slices)):

--- a/axidence/plugins/salting/events_salting.py
+++ b/axidence/plugins/salting/events_salting.py
@@ -299,7 +299,7 @@ class VetoAwareEventSalting(EventsSalting):
                 f"Vetoed {self.n_events - np.sum(mask)} salting events due to veto intervals."
             )
             self.events_salting = self.events_salting[mask]
-            self.events_salting -= self.events_salting[0]["salt_number"]  # Re-index salt_number
+            self.events_salting["salt_number"] -= self.events_salting[0]["salt_number"]  # Re-index salt_number
             self.n_events = len(self.events_salting)
 
         for chunk_i in range(len(self.slices)):

--- a/axidence/plugins/salting/events_salting.py
+++ b/axidence/plugins/salting/events_salting.py
@@ -272,7 +272,7 @@ class EventsSalting(ExhaustPlugin, DownChunkingPlugin, EventPositions, EventBasi
 
 
 class VetoAwareEventSalting(EventsSalting):
-    __version__ = "0.0.1"
+    __version__ = "0.0.2"
     child_plugin = True
     depends_on = ("run_meta", "veto_intervals")  # type: ignore[assignment]
     provides = "events_salting"

--- a/axidence/plugins/salting/events_salting.py
+++ b/axidence/plugins/salting/events_salting.py
@@ -274,7 +274,7 @@ class EventsSalting(ExhaustPlugin, DownChunkingPlugin, EventPositions, EventBasi
 class VetoAwareEventSalting(EventsSalting):
     __version__ = "0.0.1"
     child_plugin = True
-    depends_on = ("run_meta", "veto_intervals")
+    depends_on = ("run_meta", "veto_intervals")  # type: ignore[assignment]
     provides = "events_salting"
     data_kind = "events_salting"
 

--- a/axidence/plugins/salting/events_salting.py
+++ b/axidence/plugins/salting/events_salting.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 from scipy.interpolate import interp1d
 import strax
@@ -283,7 +284,8 @@ class VetoAwareEventSalting(EventsSalting):
         # Remove events that fall within veto intervals
         if len(veto_intervals) > 0:
             mask = np.ones(self.n_events, dtype=bool)
-            for v_start, v_end in veto_intervals:
+            for veto_interval in veto_intervals:
+                v_start, v_end = veto_interval['time'], veto_interval['endtime']
                 mask &= ~(
                     (self.events_salting["time"] >= v_start)
                     & (self.events_salting["time"] <= v_end)

--- a/axidence/plugins/salting/events_salting.py
+++ b/axidence/plugins/salting/events_salting.py
@@ -277,6 +277,10 @@ class VetoAwareEventSalting(EventsSalting):
     provides = "events_salting"
     data_kind = "events_salting"
 
+    def setup(self):
+        super().setup()
+        self.logger = logging.getLogger(self.__class__.__name__)
+
     def compute(self, run_meta, veto_intervals, start, end):
         """Copy and assign the salting events into chunk."""
         self.sampling(start, end)
@@ -290,7 +294,7 @@ class VetoAwareEventSalting(EventsSalting):
                     (self.events_salting["time"] >= v_start)
                     & (self.events_salting["time"] <= v_end)
                 )
-            logging.info(
+            self.logger.debug(
                 f"Vetoed {self.n_events - np.sum(mask)} salting events due to veto intervals."
             )
             self.events_salting = self.events_salting[mask]

--- a/axidence/plugins/salting/events_salting.py
+++ b/axidence/plugins/salting/events_salting.py
@@ -270,6 +270,7 @@ class EventsSalting(ExhaustPlugin, DownChunkingPlugin, EventPositions, EventBasi
                 start=_start, end=_end, data=self.events_salting[indices[0] : indices[1]]
             )
 
+
 class VetoAwareEventSalting(EventsSalting):
     __version__ = "0.0.1"
     child_plugin = True
@@ -289,7 +290,7 @@ class VetoAwareEventSalting(EventsSalting):
         if len(veto_intervals) > 0:
             mask = np.ones(self.n_events, dtype=bool)
             for veto_interval in veto_intervals:
-                v_start, v_end = veto_interval['time'], veto_interval['endtime']
+                v_start, v_end = veto_interval["time"], veto_interval["endtime"]
                 mask &= ~(
                     (self.events_salting["time"] >= v_start)
                     & (self.events_salting["time"] <= v_end)

--- a/axidence/plugins/salting/events_salting.py
+++ b/axidence/plugins/salting/events_salting.py
@@ -268,3 +268,45 @@ class EventsSalting(ExhaustPlugin, DownChunkingPlugin, EventPositions, EventBasi
             yield self.chunk(
                 start=_start, end=_end, data=self.events_salting[indices[0] : indices[1]]
             )
+
+class VetoAwareEventSalting(EventsSalting):
+    __version__ = "0.0.1"
+    child_plugin = True
+    depends_on = ("run_meta", "veto_intervals")
+    provides = "events_salting"
+    data_kind = "events_salting"
+
+    def compute(self, run_meta, veto_intervals, start, end):
+        """Copy and assign the salting events into chunk."""
+        self.sampling(start, end)
+
+        # Remove events that fall within veto intervals
+        if len(veto_intervals) > 0:
+            mask = np.ones(self.n_events, dtype=bool)
+            for v_start, v_end in veto_intervals:
+                mask &= ~(
+                    (self.events_salting["time"] >= v_start)
+                    & (self.events_salting["time"] <= v_end)
+                )
+            logging.info(
+                f"Vetoed {self.n_events - np.sum(mask)} salting events due to veto intervals."
+            )
+            self.events_salting = self.events_salting[mask]
+            self.n_events = len(self.events_salting)
+
+        for chunk_i in range(len(self.slices)):
+            indices = self.slices[chunk_i]
+
+            if chunk_i == 0:
+                _start = start
+            else:
+                _start = self.events_salting["time"][indices[0]] - self.time_left
+
+            if chunk_i == len(self.slices) - 1:
+                _end = end
+            else:
+                _end = self.events_salting["time"][indices[1] - 1] + self.time_right
+
+            yield self.chunk(
+                start=_start, end=_end, data=self.events_salting[indices[0] : indices[1]]
+            )

--- a/axidence/plugins/salting/events_salting.py
+++ b/axidence/plugins/salting/events_salting.py
@@ -299,7 +299,9 @@ class VetoAwareEventSalting(EventsSalting):
                 f"Vetoed {self.n_events - np.sum(mask)} salting events due to veto intervals."
             )
             self.events_salting = self.events_salting[mask]
-            self.events_salting["salt_number"] -= self.events_salting[0]["salt_number"]  # Re-index salt_number
+            self.events_salting["salt_number"] -= self.events_salting[0][
+                "salt_number"
+            ]  # Re-index salt_number
             self.n_events = len(self.events_salting)
 
         for chunk_i in range(len(self.slices)):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,23 +1,20 @@
-from unittest import TestCase
-
+import pytest
 import axidence
 
-
-class TestContext(TestCase):
-    def setUp(self) -> None:
-        self.st = axidence.ordinary_context()
-
+    
+class TestContext:
     def test_replication_tree(self):
         """Test the replication_tree method."""
+        self.st = axidence.ordinary_context()
         self.st.replication_tree()
-        with self.assertRaises(
-            ValueError, msg="Should raise error calling replication_tree twice!"
-        ):
+        with pytest.raises(ValueError):
             self.st.replication_tree()
 
-    def test_salt_and_pair_to_context(self):
+    @pytest.mark.parametrize("veto_aware", [False, True])
+    def test_salt_and_pair_to_context(self, veto_aware):
         """Test the salt_and_pair_to_context method."""
-        self.st.salt_and_pair_to_context()
+        self.st = axidence.ordinary_context()
+        self.st.salt_and_pair_to_context(veto_aware=veto_aware)
 
         graph_dir = "./graphs_nT"
         self.st.dependency_tree("event_info", to_dir=graph_dir)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,7 +1,7 @@
 import pytest
 import axidence
 
-    
+
 class TestContext:
     def test_replication_tree(self):
         """Test the replication_tree method."""

--- a/tests/test_salting.py
+++ b/tests/test_salting.py
@@ -1,6 +1,7 @@
 import pytest
 from straxen.test_utils import nt_test_context, nt_test_run_id
 
+
 @pytest.mark.usefixtures("rm_strax_data")
 class TestSalting:
     @pytest.mark.parametrize("veto_aware", [False, True])

--- a/tests/test_salting.py
+++ b/tests/test_salting.py
@@ -1,19 +1,10 @@
 import pytest
-from unittest import TestCase
 from straxen.test_utils import nt_test_context, nt_test_run_id
 
-
 @pytest.mark.usefixtures("rm_strax_data")
-class TestSalting(TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.run_id = nt_test_run_id
-        # TODO: xenonnt_online should be used here
-        cls.st = nt_test_context("xenonnt")
-        cls.st.salt_to_context()
-
-    def test_salting(self):
-        """Test the computing of salting plugins."""
+class TestSalting:
+    @pytest.mark.parametrize("veto_aware", [False, True])
+    def test_salting(self, veto_aware):
         peak_level_plugins = [
             "peaks_salted",
             "peak_proximity_salted",
@@ -30,7 +21,11 @@ class TestSalting(TestCase):
             "events_combine",
             "cuts_event_building_salted",
         ]
+        self.run_id = nt_test_run_id
+        self.st = nt_test_context("xenonnt")
+        self.st.salt_to_context(veto_aware=veto_aware)
         self.st.make(self.run_id, "run_meta", save="run_meta")
         self.st.make(self.run_id, "events_salting", save="events_salting")
+
         for p in peak_level_plugins + event_level_plugins:
             self.st.make(self.run_id, p, save=p)


### PR DESCRIPTION
This PR introduces veto aware salting, removing salted events when they fall within veto intervals.

To use this new feature, use:

```python
st.salt_and_pair_to_context(veto_aware=True)
```